### PR TITLE
Correct the rendering logic.

### DIFF
--- a/Multi-Threading/MutliThreadingSample/Renderer.txt
+++ b/Multi-Threading/MutliThreadingSample/Renderer.txt
@@ -1,0 +1,15 @@
+TotalThreads=100
+activeThreads=5 
+BaseInit=true 
+processes=Rasterizer
+RasterizerOptions=[
+       silent=false, 
+       noapdfl=false, 
+       InFileName=%constitution.pdf,
+       OutFilePath=Output,
+       NumberOfPages=2,
+       repetitions=5,
+       SaveImages=true,
+       Resolution=300,
+       ColorModel=DeviceRGB
+                    ]


### PR DESCRIPTION
Correct the page selection logic in both the rendering, and Text Extract workers.
Add a new command file (renderer.txt) to run just the render thread.
Use a string, rather than an atom, to select the color model for rendering.

Signed-off-by: Michael McKeough <mjm@datalogics.com>