### PR TITLE
Add a new metric, Percentage of time spent in active CPU. It will col…

### DIFF
--- a/Multi-Threading/MutliThreadingSample/MTHeader.h
+++ b/Multi-Threading/MutliThreadingSample/MTHeader.h
@@ -522,6 +522,7 @@ typedef struct
     time_t          startTime, endTime;                 /* Used in Unix only, wall time started/stopped */
     clock_t         startCPU, endCPU;                   /* Used in Unix only to track CPU time used. */
     double          wallTimeUsed, cpuTimeUsed;          /* Walltime start to finish, and CPU time (user and kernal) consumed */
+    double          percentUtilized;                    /* Percentage of CPU time in wall time */
     bool            silent;                             /* When true, write nothing to stdout! */
     bool            noAPDFL;                            /* When true, do not init/term the library in this thread! */
     bool            threadCompleted;                    /* Mark the thread complete for unix to locate it */
@@ -703,6 +704,7 @@ public:
         info->endCPU = clock ();
         info->wallTimeUsed = ((info->endTime - info->startTime) * 1.0) / CLOCKS_PER_SEC;
         info->cpuTimeUsed = ((info->endCPU - info->startCPU) * 1.0) / CLOCKS_PER_SEC;
+        doneThread->percentUtilized = (doneThread->cpuTimeUsed / dontThread->wallTimeUsed) * 100;
 #endif
 
         info->threadCompleted = true;


### PR DESCRIPTION
…lect per thread, and report in the thread shutdown.  It will also accumualte as an average, and that average will be reported at test completion.

Add a new command to the main logic. "PauseEvery" is a list of numeric values. We will pause after the number specified, cycling through the list of numbers. The purpose of this is to better represent the web environment, where there may be time when no thread is active. This goes to the time spent in Init/Term.

Split the switch to call the specific worker thread out from the outerthread. This was done to more easily allow the next change.

Run each worker thread inside a try/catch, and if APDFL is active, inside a DURING/HANDLER as well. This will catch any uncaught exceptions thrown by the workers, and assure that we always properly shut down the library.

Signed-off-by: Michael McKeough <mjm@datalogics.com>