### PR TITLE
Correct issues in selecting and running threads.

### DIFF
--- a/Multi-Threading/MultiThreadingSample/Default_Commands.txt
+++ b/Multi-Threading/MultiThreadingSample/Default_Commands.txt
@@ -52,7 +52,8 @@ TextExtractOptions=[
        silent=true, 
        LoadPlugins=false,
       noapdfl=false, 
-       NumberOfPages=1
+       NumberOfPages=1,
+       SaveWordList=false
        ]
 RasterizerOptions=[
        InFileName=%constitution.pdf,

--- a/Multi-Threading/MultiThreadingSample/Flattener.txt
+++ b/Multi-Threading/MultiThreadingSample/Flattener.txt
@@ -1,10 +1,10 @@
-TotalThreads=500
+TotalThreads=100
 activeThreads=8
 BaseInit=true 
 processes=Flattener
 PauseEvery=0
 TempMemFileSys=false
-FlattenOptions=[
+FlattenerOptions=[
        silent=true, 
        noapdfl=false, 
        LoadPlugins=true,

--- a/Multi-Threading/MultiThreadingSample/Flattener_Worker.cpp
+++ b/Multi-Threading/MultiThreadingSample/Flattener_Worker.cpp
@@ -31,8 +31,9 @@ void FlattenWorker::ParseOptions (attributes *FrameAttributes, WorkerType *worke
 {
     WorkerIDEntry = worker;
     worker->name = "Flattener";
-    worker->LoadPlugins = false;
+    worker->LoadPlugins = true;
     worker->paramName = "FlattenerOptions";
+    worker->type = workerType;
 
     /* Parse the common attributes for this worker type,
     ** Provide defaults for InFileName and OutFilePath
@@ -136,14 +137,17 @@ void FlattenWorker::WorkerThread (ThreadInfo *info)
             &flattenParams);             //Flattener options.
         if (flattenResult)
         {
-            std::cout << "Flattened " << numFlattened << " pages." << std::endl;
+            if (!silent)
+                fprintf (info->logFile, " flattened %01d pages.\n", numFlattened);
         }
-        else
+        else 
         {
-            std::cout << "Flattening failed." << std::endl;
+            if (!silent)
+                fprintf (info->logFile, "Flattening failed.\n");
             ASRaise (GenError (genErrGeneral));
         }
-        printf ("outputfile name: %s\n", fullOutputFileName);
+        if (!silent)
+            printf ("outputfile name: %s\n", fullOutputFileName);
         /* Save the output PDF Document */
         inDoc.saveDoc (fullOutputFileName); //fullOutputFileName
         /* Release the output file name */
@@ -168,8 +172,9 @@ ASBool flattenerProgMon (ASInt32 pageNum, ASInt32 totalPages, float current, ASI
     //If we've begun a new page, or if we've finished.
     if (pageNum != (data->prevPage) || current == 100.0f)
     {
-        //Print the completion percentage.
-        fprintf (data->logFile, "[%0.06g%%] Flattening page %01d of %01d.\n", current, pageNum + 1, totalPages);
+        if (!data->silent)
+            //Print the completion percentage.
+            fprintf (data->logFile, "[%0.06g%%] Flattening page %01d of %01d.\n", current, pageNum + 1, totalPages);
 
         //Update previous page.
         data->prevPage = pageNum;

--- a/Multi-Threading/MultiThreadingSample/MultiThreadingSample.cpp
+++ b/Multi-Threading/MultiThreadingSample/MultiThreadingSample.cpp
@@ -371,8 +371,8 @@ int main(int argc, char** argv)
 
                 if (!strcmp (workerName, processName))
                 {
-                    workerList[index].PDFa = workerClasses[workers[x].sequence].PDFa;
-                    workerTypeList[index] = workers[x].sequence;
+                    workerList[index].PDFa = workerClasses[workers[x].type].PDFa;
+                    workerTypeList[index] = workers[x].type;
                     break;
                 }
             }

--- a/Multi-Threading/MultiThreadingSample/NonAPDFL_Worker.cpp
+++ b/Multi-Threading/MultiThreadingSample/NonAPDFL_Worker.cpp
@@ -31,6 +31,7 @@ void NonAPDFLWorker::ParseOptions (attributes *frameAttributes, WorkerType *work
     worker->name = "NonAPDFL";
     worker->LoadPlugins = false;
     worker->paramName = "NonAPDFLOptions"; 
+    worker->type = workerType;
 
     /* Parse the common attributes for this worker type,
     ** Provide defaults for InFileName and OutFilePath

--- a/Multi-Threading/MultiThreadingSample/PDFA_Worker.cpp
+++ b/Multi-Threading/MultiThreadingSample/PDFA_Worker.cpp
@@ -30,8 +30,9 @@ void PDFaWorker::ParseOptions (attributes *FrameAttributes, WorkerType *worker)
     /* Fill in the worker interface table for this worker type */
     WorkerIDEntry = worker;
     worker->name = "PDFa";
-    worker->LoadPlugins = false;
+    worker->LoadPlugins = true;
     worker->paramName = "PDFaOptions";
+    worker->type = workerType;
 
     /* Parse the common attributes for this worker type,
     ** Provide defaults for InFileName and OutFilePath

--- a/Multi-Threading/MultiThreadingSample/PDFX_Worker.cpp
+++ b/Multi-Threading/MultiThreadingSample/PDFX_Worker.cpp
@@ -23,8 +23,9 @@ void PDFxWorker::ParseOptions (attributes *FrameAttributes, WorkerType *worker)
     /* Fill in the worker interface table for this worker type */
     WorkerIDEntry = worker;
     worker->name = "PDFx";
-    worker->LoadPlugins = false;
+    worker->LoadPlugins = true;
     worker->paramName = "PDFxOptions";
+    worker->type = workerType;
 
     /* Parse the common attributes for this worker type,
     ** Provide defaults for InFileName and OutFilePath

--- a/Multi-Threading/MultiThreadingSample/PDFa.txt
+++ b/Multi-Threading/MultiThreadingSample/PDFa.txt
@@ -1,5 +1,5 @@
-TotalThreads=10
-activeThreads=5 
+TotalThreads=100
+activeThreads=8
 BaseInit=true 
 processes=PDFa
 PauseEvery=0
@@ -7,7 +7,7 @@ TempMemFileSys=false
 PDFaOptions=[
        silent=false, 
        noapdfl=false, 
-       InFileName=%trans_1page.pdf,
+       InFileName=%trans_multipage.pdf,
        OutFilePath=Output,
        ConvertOption=RGB1b,
        LoadPlugins=true,

--- a/Multi-Threading/MultiThreadingSample/Rasterizer_Worker.cpp
+++ b/Multi-Threading/MultiThreadingSample/Rasterizer_Worker.cpp
@@ -39,6 +39,7 @@ void RasterizerWorker::ParseOptions (attributes *FrameAttributes, WorkerType *wo
     worker->name = "Rasterizer";
     worker->LoadPlugins = false;
     worker->paramName = "RasterizerOptions";
+    worker->type = workerType;
 
     /* Parse the common attributes for this worker type,
     ** Provide defaults for InFileName and OutFilePath

--- a/Multi-Threading/MultiThreadingSample/Renderer.txt
+++ b/Multi-Threading/MultiThreadingSample/Renderer.txt
@@ -1,5 +1,5 @@
 TotalThreads=100
-activeThreads=5 
+activeThreads=8
 BaseInit=true 
 processes=Rasterizer
 RasterizerOptions=[

--- a/Multi-Threading/MultiThreadingSample/TextExtract.txt
+++ b/Multi-Threading/MultiThreadingSample/TextExtract.txt
@@ -1,5 +1,5 @@
 TotalThreads=100
-activeThreads=8
+activeThreads=5
 BaseInit=true
 processes=TextExtract
 TextExtractOptions=[

--- a/Multi-Threading/MultiThreadingSample/TextExtract_Worker.h
+++ b/Multi-Threading/MultiThreadingSample/TextExtract_Worker.h
@@ -10,6 +10,7 @@
 **                   OutFilePath=[Output]                               Directory where output is written
 **                   noAPDFL=false                                      When true, we will NOT init/term the library for each thread
 **                   NumberOfPages=[1]                                  Number of pages of content to extract in this thread (100 values max!)
+**                   SaveWordList=false                                 If true, the words will be written to a file.If false, not. 
 */
 #include "MTHeader.h"
 #include "Worker.h"
@@ -33,5 +34,6 @@ public:
 private:
     ASUns32 pages[100];
     ASUns32 pagesCount;
+    bool    saveWordList;
 
 };

--- a/Multi-Threading/MultiThreadingSample/Utilities.h
+++ b/Multi-Threading/MultiThreadingSample/Utilities.h
@@ -18,6 +18,7 @@
 #define NUM_COLOR_PROFS 1    //The number of color profile directories we'll include during initialization.
 #define NUM_PLUGIN_DIRS 1    //The number of plugin directories we'll include during initialization.
 
+#include <io.h>
 #include <iostream>
 #include <cstring>
 #include <vector>
@@ -25,8 +26,6 @@
 #include "PDFLCalls.h"
 #include "ASCalls.h"
 #include "ASExtraCalls.h"
-
-
 
 
 #ifdef AIX_GCC_COMPAT
@@ -81,7 +80,7 @@ class APDFLib
 {
 public:
     //Constructor initializes APDFL and sets the path to DL150PDFL.dll to dl150Dir. If NULL is passed, defaults to ../../../Binaries. dl150Dir should be a relative path.
-    APDFLib(ASUns32 flags = 0, wchar_t* dl150Dir = NULL);
+    APDFLib (ASUns32 flags = 0, char* binariesPath = NULL, char *pluginsPath = NULL, char *resourcesPath = NULL);
     ~APDFLib();                                       //Destructor terminates APDFL.
 
     ASInt32 getInitError();                           //Reports whether an error happened during initialization and returns that error.
@@ -96,7 +95,7 @@ private:
 
     void fillDirectories();                           //Sets directory information for our PDFLDataRec.
 #if WIN_PLATFORM
-    HINSTANCE loadDFL150PDFL(wchar_t* relativeDir);   //Loads the DL150PDFL library dynamically.
+    HINSTANCE loadDL150PDFL(char* relativeDir);   //Loads the DL150PDFL library dynamically.
 #endif
 
     ASUTF16Val* fontDirList[NUM_FONTS];               //List of font directories we'll include during initialization.              //TODO: platform divergences
@@ -106,6 +105,10 @@ private:
     GCCAIXHelper gccHelp;
 #endif
 
+
+    char BinariesPath[2048];
+    char PluginsPath[2048];
+    char ResourcesPath[2048];
 };
 
 class APDFLDoc

--- a/Multi-Threading/MultiThreadingSample/Worker.h
+++ b/Multi-Threading/MultiThreadingSample/Worker.h
@@ -57,7 +57,7 @@ typedef struct worktypes
 {
     char                *name;
     char                *paramName;
-    int                  sequence;
+    EnumOfWorkers        type;
     bool                 LoadPlugins;
 } WorkerType;
 

--- a/Multi-Threading/MultiThreadingSample/XPS2PDF.txt
+++ b/Multi-Threading/MultiThreadingSample/XPS2PDF.txt
@@ -1,5 +1,5 @@
-TotalThreads=10
-activeThreads=5 
+TotalThreads=100
+activeThreads=7
 BaseInit=true 
 processes=XPS2PDF
 PauseEvery=0

--- a/Multi-Threading/MultiThreadingSample/XPS2PDF_Worker.cpp
+++ b/Multi-Threading/MultiThreadingSample/XPS2PDF_Worker.cpp
@@ -26,8 +26,9 @@ void XPS2PDFWorker::ParseOptions (attributes *FrameAttributes, WorkerType *worke
 {    /* Fill in the worker interface table for this worker type */
     WorkerIDEntry = worker;
     worker->name = "XPS2PDf";
-    worker->LoadPlugins = false;
+    worker->LoadPlugins = true;
     worker->paramName = "XPS2PDFOptions";
+    worker->type = workerType;
 
     /* Parse the common attributes for this worker type,
     ** Provide defaults for InFileName and OutFilePath


### PR DESCRIPTION
Silence some messages in Flattener.
Add new Option SaveWordList for textextract.
Correct default setting of LoadPlugins.
Change default doc used in PDFs/txt
Ground work for putting paths in command

Signed-off-by: Michael McKeough <mjm@datalogics.com>